### PR TITLE
ENG-5409 add new env var `PAUSE`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM busybox:1.36.0
 
 ENV REPO_PATH="https://raw.github.com/entando-ps/cds/entando720/entando-data/" \
     ARCHIVE_NAME="entando720.tar.gz" \
-    FORCE_CDS=false
+    FORCE_CDS=false \
+    PAUSE=false
 
 COPY --chmod=0755 init.sh /init.sh
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Repository to manage the configuration of the CDS init container based on busybo
 | Name      | Default Value                                                  | Description                                                 |
 |-----------|----------------------------------------------------------------|-------------------------------------------------------------|
 | REPO_PATH | https://raw.github.com/entando-ps/cds/entando720/entando-data/ | The path of the GitHub repository used to store the archive |
-| ARCHIVE_NAME | entando720.tar.gz | The name of the archive containing all the Entando static resources |
-| FORCE_CDS | false | Needed to force the overwriting of the volume | 
+| ARCHIVE_NAME | entando730.tar.gz                                              | The name of the archive containing all the Entando static resources |
+| FORCE_CDS | false                                                          | Needed to force the overwriting of the volume | 
+| PAUSE   | false                                                          | Used to stop the init-container execution for a specified amount of time | SUSPEND_TIME |     | Pause for number
+| PAUSE_TIME |                                                                | Pause for number seconds(default value). `s[default], m, h, d` can be specified as suffix to express:                  |
 
+- **3s** -> 3 seconds
+- **3m** -> 3 minutes
+- **3h** -> 3 hours
+- **3d** -> 3 days
+
+
+
+
+If `PAUSE` is true, then also `PAUSE_TIME` must be specified.

--- a/init.sh
+++ b/init.sh
@@ -4,6 +4,16 @@ set -xe
 DIRECTORY="/entando-data/public"
 FINAL_PATH="$REPO_PATH$ARCHIVE_NAME"
 
+if "$PAUSE"; then
+  if [ -z "$PAUSE_TIME" ]; then
+    echo "PAUSE_TIME env var must be specified."
+    exit 44
+  fi
+  echo "Sleeping for $PAUSE_TIME"
+  sleep "$PAUSE_TIME"
+fi
+
+
 if [ ! -d "$DIRECTORY" ]; then
     wget --no-check-certificate "$FINAL_PATH" -P /tmp
     tar -xf /tmp/"$ARCHIVE_NAME" -C /


### PR DESCRIPTION
Add new env var `PAUSE` and `PAUSE_TIME` to manage the sleep time of the init-container.